### PR TITLE
Add Multi-Threading and BM25 Retrieval Options

### DIFF
--- a/App.config
+++ b/App.config
@@ -15,5 +15,15 @@
 
     <!-- Specify the maximum number of records to process -->
     <add key="MaxRecords" value="10" />
+
+    <!-- Enable or disable multi-threading for embedding generation -->
+    <!-- If set to 'true', embeddings will be created in parallel for faster processing. Use 'false' for sequential execution. -->
+    <add key="MultiThreadEmbedding" value="true" />
+
+    <!-- Options: "Cosine" or "BM25" -->
+    <!-- Determines the similarity method used for finding the most relevant content. 
+         - 'Cosine': Compares embedding vectors (Semantic match).
+         - 'BM25': Uses a text-based (keyword match) retrieval approach for relevance scoring. -->
+    <add key="SimilarityMethod" value="BM25" />
   </appSettings>
 </configuration>

--- a/Helpers/DataverseManager.cs
+++ b/Helpers/DataverseManager.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
@@ -21,38 +22,103 @@ namespace OllamaDataverseEntityChatApp.Helpers
 
         public static QueryExpression BuildQueryFromMetadata(EntityMetadata metadata, string entity)
         {
-            if (entity == "flowrun")
+            switch (entity)
             {
-                var query = new QueryExpression(entity);
-                query.ColumnSet.AddColumns("flowrunid", "name", "createdon", "status", "starttime", "endtime", "duration", "triggertype");
-
-                var workflowLink = query.AddLink("workflow", "workflow", "workflowid", JoinOperator.LeftOuter);
-                workflowLink.EntityAlias = "wf";
-                workflowLink.Columns.AddColumns("name", "primaryentity", "description");
-
-                query.AddOrder("createdon", OrderType.Descending);
-                return query;
+                case "flowrun":
+                    return BuildFlowRunQuery();
+                case "plugintracelog":
+                    return BuildPluginTraceLogQuery();
+                default:
+                    return BuildDefaultQuery(metadata, entity);
             }
-            else if (entity == "plugintracelog")
+        }
+
+        private static QueryExpression BuildFlowRunQuery()
+        {
+            var query = new QueryExpression("flowrun");
+            query.ColumnSet.AddColumns("flowrunid", "name", "createdon", "status",
+                "starttime", "endtime", "duration", "triggertype");
+
+            var workflowLink = query.AddLink("workflow", "workflow", "workflowid", JoinOperator.LeftOuter);
+            workflowLink.EntityAlias = "wf";
+            workflowLink.Columns.AddColumns("name", "primaryentity", "description", "statecode");
+
+            query.AddOrder("createdon", OrderType.Descending);
+            return query;
+        }
+
+        public static string FormatFlowRunRecord(Entity record)
+        {
+            var flowName = record.Contains("wf.name")
+                ? record.GetAttributeValue<AliasedValue>("wf.name").Value.ToString()
+                : "Unnamed Flow";
+            var status = record.Contains("status") ? record["status"].ToString() : "Unknown";
+            var startTime = record.Contains("starttime") ? record["starttime"].ToString() : "Unknown";
+            var endTime = record.Contains("endtime") ? record["endtime"].ToString() : "Unknown";
+            var duration = record.Contains("duration") ? record["duration"].ToString() : "Unknown";
+            var triggerType = record.Contains("triggertype") ? record["triggertype"].ToString() : "Unknown";
+
+            return $"Flow '{flowName}' execution:" +
+                $" Status: {status}, Start: {startTime}, End: {endTime}" +
+                $" Duration: {duration}, Trigger Type: {triggerType}";
+        }
+
+        private static QueryExpression BuildPluginTraceLogQuery()
+        {
+            var query = new QueryExpression("plugintracelog");
+            query.ColumnSet.AddColumns("createdon", "messagename", "operationtype",
+                "messageblock", "exceptiondetails", "performanceexecutionduration");
+            query.Criteria.AddCondition("exceptiondetails", ConditionOperator.NotNull);
+            query.AddOrder("createdon", OrderType.Descending);
+            return query;
+        }
+
+        public static string FormatPluginTraceLogRecord(Entity record)
+        {
+            var messageBlock = record.Contains("messageblock") ? record["messageblock"].ToString() : "No message";
+            var exceptionDetails = record.Contains("exceptiondetails") ? record["exceptiondetails"].ToString() : "No exception";
+            var messageName = record.Contains("messagename") ? record["messagename"].ToString() : "Unknown";
+            var operationType = record.Contains("operationtype") ? record["operationtype"].ToString() : "Unknown";
+            var executionDuration = record.Contains("performanceexecutionduration") ? record["performanceexecutionduration"].ToString() : "Unknown";
+            var createdOn = record.Contains("createdon") ? record["createdon"].ToString() : "Unknown";
+
+            return $"Plugin Trace Log:" +
+                $" Created: {createdOn}, Message: {messageName}" +
+                $" Operation: {operationType}, Duration: {executionDuration}" +
+                $" Details: {messageBlock}" +
+                $" Exception: {exceptionDetails}";
+        }
+
+        public static string FormatDefaultRecord(Entity record, int index)
+        {
+            return $"Record {index + 1}:" +
+                string.Join(", ", record.Attributes
+                    .Select(attr => $"{attr.Key}: {attr.Value}"));
+        }
+
+        public static string FormatRecordSummary(Entity record, string entity, int index)
+        {
+            return entity switch
             {
-                var query = new QueryExpression(entity);
-                query.ColumnSet.AddColumns("createdon", "messageblock", "exceptiondetails");
-                query.Criteria.AddCondition("exceptiondetails", ConditionOperator.NotNull);
-                query.AddOrder("createdon", OrderType.Descending);
-                return query;
-            }
+                "flowrun" => FormatFlowRunRecord(record),
+                "plugintracelog" => FormatPluginTraceLogRecord(record),
+                _ => FormatDefaultRecord(record, index)
+            };
+        }
 
-            var defaultQuery = new QueryExpression(entity)
+        private static QueryExpression BuildDefaultQuery(EntityMetadata metadata, string entity)
+        {
+            var query = new QueryExpression(entity)
             {
                 ColumnSet = new ColumnSet(metadata.Attributes
                     .Where(a => a.IsValidForRead.GetValueOrDefault()
-                        && !a.LogicalName.Contains("_") // Filter out related attributes
-                        && !a.LogicalName.EndsWith("name")) // Filter out name fields of lookups
+                        && !a.LogicalName.Contains("_")
+                        && !a.LogicalName.EndsWith("name"))
                     .Select(a => a.LogicalName)
                     .ToArray())
             };
-            defaultQuery.AddOrder("createdon", OrderType.Descending);
-            return defaultQuery;
+            query.AddOrder("createdon", OrderType.Descending);
+            return query;
         }
     }
 }

--- a/Helpers/OllamaManager.cs
+++ b/Helpers/OllamaManager.cs
@@ -4,7 +4,8 @@ namespace OllamaDataverseEntityChatApp.Helpers
 {
     public static class OllamaManager
     {
-        private static string BaseUrl => $"http://{ConfigurationManager.AppSettings["OllamaHost"]}:{ConfigurationManager.AppSettings["OllamaPort"]}";
+        private static string BaseUrl => $"https://{ConfigurationManager.AppSettings["OllamaHost"]}";
+
         public static Uri GetOllamaUri() => new Uri(BaseUrl);
 
         public static List<(List<string> text, float[] embedding)> FindMostRelevantChunks(
@@ -19,7 +20,7 @@ namespace OllamaDataverseEntityChatApp.Helpers
                 .ToList();
         }
 
-        private static float CosineSimilarity(float[] a, float[] b)
+        public static float CosineSimilarity(float[] a, float[] b)
         {
             float dotProduct = 0;
             float normA = 0;
@@ -31,6 +32,86 @@ namespace OllamaDataverseEntityChatApp.Helpers
                 normB += b[i] * b[i];
             }
             return dotProduct / (float)(Math.Sqrt(normA) * Math.Sqrt(normB));
+        }
+
+        public static List<(List<string> text, double score)> FindMostRelevantChunksBM25(
+            string query,
+            Dictionary<int, List<string>> chunks,
+            int topK)
+        {
+            var tokenizedQuery = query.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                                    .Select(t => t.ToLowerInvariant())
+                                    .ToList();
+
+            var docFreq = CalculateDocumentFrequencies(chunks.Values.ToList());
+            var avgDocLength = chunks.Values.Average(doc => doc.Count);
+
+            const float k1 = 1.5f; // BM25 parameter
+            const float b = 0.75f; // BM25 parameter
+
+            var scores = chunks.Select(chunk => {
+                double score = CalculateBM25Score(
+                    tokenizedQuery,
+                    chunk.Value,
+                    docFreq,
+                    avgDocLength,
+                    k1,
+                    b);
+                return (chunk.Value, score);
+            });
+
+            return scores
+                .OrderByDescending(x => x.score)
+                .Take(topK)
+                .ToList();
+        }
+
+        private static Dictionary<string, int> CalculateDocumentFrequencies(List<List<string>> documents)
+        {
+            var docFreq = new Dictionary<string, int>();
+            foreach (var doc in documents)
+            {
+                var uniqueTerms = doc.Select(t => t.ToLowerInvariant()).Distinct();
+                foreach (var term in uniqueTerms)
+                {
+                    if (!docFreq.ContainsKey(term))
+                        docFreq[term] = 0;
+                    docFreq[term]++;
+                }
+            }
+            return docFreq;
+        }
+
+        private static double CalculateBM25Score(
+            List<string> queryTerms,
+            List<string> document,
+            Dictionary<string, int> docFreq,
+            double avgDocLength,
+            float k1,
+            float b)
+        {
+            double score = 0;
+            var docLength = document.Count;
+            var termFreq = document
+                .GroupBy(t => t.ToLowerInvariant())
+                .ToDictionary(g => g.Key, g => g.Count());
+
+            var totalDocuments = docFreq.Values.Max(); // Get total number of documents from document frequencies
+
+            foreach (var term in queryTerms)
+            {
+                if (!docFreq.ContainsKey(term))
+                    continue;
+
+                var tf = termFreq.GetValueOrDefault(term, 0);
+                var df = docFreq[term];
+                var idf = Math.Log((totalDocuments - df + 0.5) / (df + 0.5) + 1);
+
+                score += idf * ((tf * (k1 + 1)) /
+                    (tf + k1 * (1 - b + b * docLength / avgDocLength)));
+            }
+
+            return score;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A command-line tool that connects to Microsoft Dataverse, retrieves data, and us
 
 ## Prerequisites
 
-- .NET 6.0 or higher
+- .NET 8.0
 - Ollama installed and running
 - Access to a Microsoft Dataverse environment
 - Sufficient GPU, disk and system memory for running AI models
@@ -30,6 +30,8 @@ xml
     <add key="OllamaHost" value="Enter Ollama host IP address here" />
     <add key="OllamaPort" value="Enter Ollama port number here" />
     <add key="MaxRecords" value="10" />
+    <add key="MultiThreadEmbedding" value="true" />
+    <add key="SimilarityMethod" value="BM25" />
 </appSettings>
 </configuration>
 


### PR DESCRIPTION
- Added two new app.config variables:
  1. MultiThreadEmbedding: Enables or disables multi-threaded embedding generation for improved performance.
  2. SimilarityMethod:Allows switching between 'Cosine' and 'BM25' similarity methods for content retrieval.

- Modified OllamaManager:
  - Added FindMostRelevantChunksBM25 for text-based BM25 retrieval.

- Refactored code to improve query-building and embedding formatting, delegating additional logic to the DataverseManager class.

- Updated README.md.